### PR TITLE
feat: generate reviewable slide PDFs from static docs in CI

### DIFF
--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -43,7 +43,10 @@ jobs:
 
       - name: Render PDF with DeckTape
         run: |
-          npx -y decktape --chrome-path "${CHROME_PATH}" automatic \
+          npx -y decktape \
+            --chrome-path "${CHROME_PATH}" \
+            --chrome-arg=--no-sandbox \
+            --chrome-arg=--disable-setuid-sandbox \
             http://127.0.0.1:8080 \
             graphql-conf-2024-slides.pdf
 

--- a/.github/workflows/generate-pdf.yml
+++ b/.github/workflows/generate-pdf.yml
@@ -1,0 +1,65 @@
+name: Generate Slides PDF
+
+on:
+  push:
+    branches:
+      - main
+      - codex/**
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  generate-pdf:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Start static slide server
+        run: |
+          npx -y live-server docs --host=127.0.0.1 --port=8080 --no-browser >/tmp/live-server.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:8080 >/dev/null; then
+              exit 0
+            fi
+            sleep 2
+          done
+          cat /tmp/live-server.log
+          exit 1
+
+      - name: Render PDF with DeckTape
+        run: |
+          npx -y decktape --chrome-path "${CHROME_PATH}" automatic \
+            http://127.0.0.1:8080 \
+            graphql-conf-2024-slides.pdf
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: graphql-conf-2024-slides-pdf
+          path: graphql-conf-2024-slides.pdf
+          if-no-files-found: error
+
+      - name: Add workflow summary
+        run: |
+          {
+            echo "## Slides PDF"
+            echo
+            echo "Artifact: \`graphql-conf-2024-slides-pdf\`"
+            echo
+            echo "Download it from this workflow run's artifacts panel."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
/claim #1

## Summary
- add a GitHub Actions workflow that serves the static `docs/` slide deck directly
- render the deck to PDF with Chrome + DeckTape instead of assuming repo-specific `npm run dev/build` scripts
- upload the generated PDF as a downloadable artifact for every PR / push to make review easy
- add a workflow summary so maintainers know exactly where to download the PDF from

## Why this approach
This repository is a static Remark slide deck under `docs/`, so a CI workflow should not depend on missing application scripts. Serving `docs/` directly produces a narrower and more reliable pipeline for the bounty requirements.

## Result
Every run will produce a `graphql-conf-2024-slides-pdf` artifact that can be downloaded from the workflow run.
