### PR TITLE
Add slides PDF generation workflow

### DIFF
--- a/.github/workflows/slides-pdf.yml
+++ b/.github/workflows/slides-pdf.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Generate PDF
         run: npm run build:pdf
 
+      - name: Check PDF
+        run: npm run check:pdf
+
       - name: Upload PDF artifact
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/slides-pdf.yml
+++ b/.github/workflows/slides-pdf.yml
@@ -1,0 +1,40 @@
+name: Generate slides PDF
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pdf:
+    name: Generate PDF artifact
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Generate PDF
+        run: npm run build:pdf
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: graphql-conf-2024-slides-${{ github.sha }}
+          path: dist/graphql-conf-2024-slides.pdf
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pdf
+dist/
+node_modules/

--- a/docs/app.css
+++ b/docs/app.css
@@ -17,22 +17,22 @@ body {
   font-size: 2rem;
   background-image: radial-gradient(
       circle at 100% 10%,
-      #ffffff11 10%,
+      rgba(255, 255, 255, 0.067) 10%,
       #000000 60%
     ),
     repeating-linear-gradient(
       0deg,
-      #ffffff22,
-      #ffffff22 0.5px,
-      #0000 1px,
-      #0000 27px
+      rgba(255, 255, 255, 0.133),
+      rgba(255, 255, 255, 0.133) 0.5px,
+      rgba(0, 0, 0, 0) 1px,
+      rgba(0, 0, 0, 0) 27px
     ),
     repeating-linear-gradient(
       90deg,
-      #ffffff22,
-      #ffffff22 0.5px,
-      #0000 1px,
-      #0000 70px
+      rgba(255, 255, 255, 0.133),
+      rgba(255, 255, 255, 0.133) 0.5px,
+      rgba(0, 0, 0, 0) 1px,
+      rgba(0, 0, 0, 0) 70px
     );
   height: 100%;
   color: #fff;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,62 @@
+{
+  "name": "graphql-conf-2024-slides",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "graphql-conf-2024-slides",
+      "version": "1.0.0",
+      "devDependencies": {
+        "playwright": "1.59.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build:pdf": "node scripts/generate-pdf.mjs"
+    "build:pdf": "node scripts/generate-pdf.mjs",
+    "check:pdf": "node scripts/check-pdf.mjs"
   },
   "devDependencies": {
     "playwright": "1.59.1"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "graphql-conf-2024-slides",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:pdf": "node scripts/generate-pdf.mjs"
+  },
+  "devDependencies": {
+    "playwright": "1.59.1"
+  }
+}

--- a/readme.md
+++ b/readme.md
@@ -7,3 +7,13 @@ Slides for the Talk "Scaling GraphQL for 500,000,000 req/min"
 ```
 npx live-server docs
 ```
+
+# Generate PDF
+
+```
+npm ci
+npx playwright install chromium
+npm run build:pdf
+```
+
+The generated PDF is written to `dist/graphql-conf-2024-slides.pdf`.

--- a/scripts/check-pdf.mjs
+++ b/scripts/check-pdf.mjs
@@ -1,0 +1,27 @@
+import { readFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+const rootDir = resolve(import.meta.dirname, "..");
+const outputName = "dist/graphql-conf-2024-slides.pdf";
+const outputFile = join(rootDir, outputName);
+const minimumBytes = 100_000;
+
+const pdf = await readFile(outputFile);
+const header = pdf.subarray(0, 5).toString("ascii");
+
+if (header !== "%PDF-") {
+  throw new Error(`${outputName} is not a PDF file`);
+}
+
+if (pdf.byteLength < minimumBytes) {
+  throw new Error(`${outputName} is unexpectedly small (${pdf.byteLength} bytes)`);
+}
+
+const text = pdf.toString("latin1");
+const pageCount = (text.match(/\/Type\s*\/Page\b/g) ?? []).length;
+
+if (pageCount < 1) {
+  throw new Error(`${outputName} does not contain any PDF pages`);
+}
+
+console.log(`Verified ${outputName}: ${pageCount} pages, ${pdf.byteLength} bytes`);

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -7,6 +7,7 @@ import { chromium } from "playwright";
 const rootDir = resolve(import.meta.dirname, "..");
 const docsDir = join(rootDir, "docs");
 const outputDir = join(rootDir, "dist");
+const outputName = "dist/graphql-conf-2024-slides.pdf";
 const outputFile = join(outputDir, "graphql-conf-2024-slides.pdf");
 const requestedPort = Number.parseInt(process.env.PDF_SERVER_PORT ?? "0", 10);
 let serverPort = requestedPort;
@@ -102,7 +103,7 @@ try {
     },
   });
 
-  console.log(`Generated ${outputFile}`);
+  console.log(`Generated ${outputName}`);
 } finally {
   await browser.close();
   await new Promise((resolveClose) => server.close(resolveClose));

--- a/scripts/generate-pdf.mjs
+++ b/scripts/generate-pdf.mjs
@@ -1,0 +1,109 @@
+import { createServer } from "node:http";
+import { createReadStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { extname, join, normalize, resolve, sep } from "node:path";
+import { chromium } from "playwright";
+
+const rootDir = resolve(import.meta.dirname, "..");
+const docsDir = join(rootDir, "docs");
+const outputDir = join(rootDir, "dist");
+const outputFile = join(outputDir, "graphql-conf-2024-slides.pdf");
+const requestedPort = Number.parseInt(process.env.PDF_SERVER_PORT ?? "0", 10);
+let serverPort = requestedPort;
+
+const contentTypes = {
+  ".css": "text/css; charset=utf-8",
+  ".gif": "image/gif",
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+  ".png": "image/png",
+  ".svg": "image/svg+xml; charset=utf-8",
+};
+
+function filePathForRequest(url) {
+  const requestUrl = new URL(url, `http://127.0.0.1:${serverPort}`);
+  const pathname = decodeURIComponent(requestUrl.pathname);
+  const requestedPath = pathname === "/" ? "/index.html" : pathname;
+  const filePath = normalize(join(docsDir, requestedPath));
+
+  if (filePath !== docsDir && !filePath.startsWith(`${docsDir}${sep}`)) {
+    return undefined;
+  }
+
+  return filePath;
+}
+
+const server = createServer((request, response) => {
+  const filePath = filePathForRequest(request.url ?? "/");
+
+  if (!filePath) {
+    response.writeHead(403);
+    response.end("Forbidden");
+    return;
+  }
+
+  const stream = createReadStream(filePath);
+
+  stream.on("open", () => {
+    response.writeHead(200, {
+      "Content-Type": contentTypes[extname(filePath)] ?? "application/octet-stream",
+    });
+    stream.pipe(response);
+  });
+
+  stream.on("error", () => {
+    response.writeHead(404);
+    response.end("Not found");
+  });
+});
+
+await mkdir(outputDir, { recursive: true });
+
+await new Promise((resolveListen, rejectListen) => {
+  server.once("error", rejectListen);
+  server.listen(requestedPort, "127.0.0.1", () => {
+    const address = server.address();
+    serverPort = typeof address === "object" && address ? address.port : requestedPort;
+    resolveListen();
+  });
+});
+
+const browser = await chromium.launch();
+
+try {
+  const page = await browser.newPage({
+    deviceScaleFactor: 1,
+    viewport: { width: 1210, height: 681 },
+  });
+
+  page.setDefaultTimeout(30000);
+
+  await page.goto(`http://127.0.0.1:${serverPort}/index.html?print-pdf`, {
+    waitUntil: "networkidle",
+  });
+
+  await page.waitForFunction(() => {
+    return window.slideshow && document.querySelectorAll(".remark-slide-container").length > 0;
+  });
+
+  await page.waitForFunction(() => Array.from(document.images).every((image) => image.complete));
+  await page.evaluate(() => document.fonts?.ready);
+
+  await page.pdf({
+    path: outputFile,
+    printBackground: true,
+    preferCSSPageSize: true,
+    margin: {
+      top: "0",
+      right: "0",
+      bottom: "0",
+      left: "0",
+    },
+  });
+
+  console.log(`Generated ${outputFile}`);
+} finally {
+  await browser.close();
+  await new Promise((resolveClose) => server.close(resolveClose));
+}


### PR DESCRIPTION
Fixes #1.
/claim #1

## Summary
- Add an npm script that serves the existing `docs` deck locally and uses Playwright/Chromium to export `index.html?print-pdf` to `dist/graphql-conf-2024-slides.pdf`.
- Add a GitHub Actions workflow that installs dependencies, generates the PDF, checks the generated artifact, and uploads it as a downloadable artifact for pushes, PRs, and manual runs.
- Document the local PDF generation steps in the README.
- Replace 4/8-digit hex alpha gradient colors with equivalent `rgba(...)` values so PDF renderers preserve the same black slide background as the HTML deck.

## Verification
- `npm ci`
- `npm run build:pdf`
- `npm run check:pdf` verified `dist/graphql-conf-2024-slides.pdf`: 32 pages, 2507450 bytes.
- Rendered the generated PDF locally and checked representative pages: first slide, middle slide, and final QR slide.
