### PR TITLE
ci: generate slide PDF artifact on push and PR

### DIFF
--- a/.github/workflows/slides-pdf.yml
+++ b/.github/workflows/slides-pdf.yml
@@ -1,0 +1,39 @@
+name: Build slides PDF
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  export-pdf:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install tooling
+        run: npm install -g decktape http-server
+
+      - name: Export slides to PDF
+        run: |
+          mkdir -p artifacts
+          npx http-server docs -p 4188 -s >/tmp/http-server.log 2>&1 &
+          SERVER_PID=$!
+          trap "kill $SERVER_PID" EXIT
+          npx decktape --chrome-arg=--no-sandbox --chrome-arg=--disable-dev-shm-usage remark http://127.0.0.1:4188/index.html artifacts/slides.pdf
+          ls -lh artifacts/slides.pdf
+
+      - name: Upload PDF artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: graphql-conf-2024-slides-pdf
+          path: artifacts/slides.pdf
+          if-no-files-found: error


### PR DESCRIPTION
/claim #1

## Summary
- add a GitHub Actions workflow to generate a PDF from the slides on every push and pull request
- serve `docs/` in CI and render `docs/index.html` (remark.js deck) via DeckTape
- upload the generated `artifacts/slides.pdf` as `graphql-conf-2024-slides-pdf` artifact

## Why
- provides a downloadable PDF artifact for each commit/PR
- keeps rendering aligned with the HTML slides by exporting from the live deck URL

## Notes
- workflow triggers on `push`, `pull_request`, and `workflow_dispatch`
- no source slide content changes included